### PR TITLE
Add post-merge config, revert the eip1559 base fee for pos

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -236,7 +236,7 @@ func (st *StateTransition) buyGas(contractCreation bool) error {
 	}
 	// this is the correct way to check the balance
 	if contractCreation {
-		if st.evm.ChainConfig().IsHydro(st.evm.Context.BlockNumber) {
+		if st.evm.ChainConfig().IsShanghai(st.evm.Context.Time) {
 			balanceCheck.Add(balanceCheck, params.CanxiumContractCreationFee)
 		} else {
 			// for backward compatible, pre-hydro fork check the contract creation independently

--- a/genesis/mainnet.genesis.json
+++ b/genesis/mainnet.genesis.json
@@ -14,7 +14,9 @@
     "londonBlock": 0,
     "canxiumBlock": 0,
     "hydroBlock": 4204800,
-    "ethash": {}
+    "ethash": {},
+    "terminalTotalDifficulty": 86680000000000000000,
+    "shanghaiTime": 1723122376
   },
   "difficulty": "400000",
   "gasLimit": "100000000",

--- a/params/config.go
+++ b/params/config.go
@@ -536,6 +536,20 @@ func (c *ChainConfig) Description() string {
 		banner += fmt.Sprintf(" - Hydro Fork:                  #%-8v \n", c.HydroBlock)
 	}
 
+	// Add a special section for the merge as it's non-obvious
+	if c.TerminalTotalDifficulty == nil {
+		banner += "The Merge is not yet available for this network!\n"
+		banner += " - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md\n"
+	} else {
+		banner += "Merge configured:\n"
+		banner += " - Hard-fork specification:    https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md\n"
+		banner += fmt.Sprintf(" - Network known to be merged: %v\n", c.TerminalTotalDifficultyPassed)
+		banner += fmt.Sprintf(" - Total terminal difficulty:  %v\n", c.TerminalTotalDifficulty)
+		if c.MergeNetsplitBlock != nil {
+			banner += fmt.Sprintf(" - Merge netsplit block:       #%-8v\n", c.MergeNetsplitBlock)
+		}
+	}
+
 	banner += "\n"
 
 	// Create a list of forks post-merge


### PR DESCRIPTION
- After the merge, block difficulty will be zero, so we will revert the way base fee is calculated.
- Add post-merge configuration: terminalTotalDifficulty and shanghaiTime