### PR TITLE
fix syncing in gcmode because of incorrect gas used

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -140,7 +140,7 @@ func Transaction(ctx *cli.Context) error {
 		}
 		// Check intrinsic gas
 		if gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil,
-			chainConfig.IsHomestead(new(big.Int)), chainConfig.IsIstanbul(new(big.Int)), chainConfig.IsShanghai(0), tx.IsMiningTx()); err != nil {
+			chainConfig.IsHomestead(new(big.Int)), chainConfig.IsIstanbul(new(big.Int)), chainConfig.IsShanghai(0), chainConfig.IsHydro(new(big.Int)), tx.IsMiningTx()); err != nil {
 			r.Error = err
 			results = append(results, r)
 			continue

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -83,7 +83,7 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 	return func(i int, gen *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
-		gas, _ := IntrinsicGas(data, nil, false, false, false, false, false)
+		gas, _ := IntrinsicGas(data, nil, false, false, false, false, false, false)
 		signer := types.MakeSigner(gen.config, big.NewInt(int64(i)))
 		gasPrice := big.NewInt(0)
 		if gen.header.BaseFee != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -64,9 +64,9 @@ func (result *ExecutionResult) Revert() []byte {
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation bool, isHomestead, isEIP2028 bool, isEIP3860 bool, isMiningTx bool) (uint64, error) {
+func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation bool, isHomestead, isEIP2028 bool, isEIP3860 bool, isHydroFork bool, isMiningTx bool) (uint64, error) {
 	// Mining transaction have zero intrinsic gas
-	if isMiningTx {
+	if isHydroFork && isMiningTx {
 		return 0, nil
 	}
 	// Set the starting gas for the raw transaction
@@ -375,7 +375,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	)
 
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
-	gas, err := IntrinsicGas(msg.Data, msg.AccessList, contractCreation, rules.IsHomestead, rules.IsIstanbul, rules.IsShanghai, msg.IsMiningTx)
+	gas, err := IntrinsicGas(msg.Data, msg.AccessList, contractCreation, rules.IsHomestead, rules.IsIstanbul, rules.IsShanghai, rules.IsHydro, msg.IsMiningTx)
 	if err != nil {
 		return nil, err
 	}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -689,7 +689,7 @@ func (pool *TxPool) validateTxBasics(tx *types.Transaction, local bool) error {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction has more gas than the basic tx fee.
-	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, pool.istanbul.Load(), pool.shanghai.Load(), tx.IsMiningTx())
+	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, pool.istanbul.Load(), pool.shanghai.Load(), pool.hydro.Load(), tx.IsMiningTx())
 	if err != nil {
 		return err
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -319,7 +319,7 @@ func (tx *Transaction) PowNonce() uint64 { return tx.inner.powNonce() }
 // Seed returns the mining seed of transaction which solve the pow
 func (tx *Transaction) MixDigest() common.Hash { return tx.inner.mixDigest() }
 
-// Difficulty returns the mining diffculty of transaction
+// Is this a mining transaction
 func (tx *Transaction) IsMiningTx() bool { return tx.Type() == MiningTxType }
 
 // To returns the sender address of the transaction.

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -65,7 +65,7 @@ type Contract struct {
 }
 
 // NewContract returns a new contract environment for the execution of EVM.
-func NewContract(caller ContractRef, object ContractRef, value *big.Int, gas uint64, miningContract common.Address) *Contract {
+func NewContract(caller ContractRef, object ContractRef, value *big.Int, gas uint64, miningContract *common.Address) *Contract {
 	c := &Contract{CallerAddress: caller.Address(), caller: caller, self: object}
 
 	if parent, ok := caller.(*Contract); ok {
@@ -80,7 +80,11 @@ func NewContract(caller ContractRef, object ContractRef, value *big.Int, gas uin
 	c.Gas = gas
 	// ensures a value is set
 	c.value = value
-	c.IsMiningContract = object.Address() == miningContract
+	if miningContract != nil {
+		c.IsMiningContract = object.Address() == *miningContract
+	} else {
+		c.IsMiningContract = false
+	}
 
 	return c
 }

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -66,7 +66,7 @@ func runTrace(tracer tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCon
 		gasLimit uint64 = 31000
 		startGas uint64 = 10000
 		value           = big.NewInt(0)
-		contract        = vm.NewContract(account{}, account{}, value, startGas, common.Address{})
+		contract        = vm.NewContract(account{}, account{}, value, startGas, nil)
 	)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
 	if contractCode != nil {
@@ -182,7 +182,7 @@ func TestHaltBetweenSteps(t *testing.T) {
 	}
 	env := vm.NewEVM(vm.BlockContext{BlockNumber: big.NewInt(1)}, vm.TxContext{GasPrice: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Tracer: tracer})
 	scope := &vm.ScopeContext{
-		Contract: vm.NewContract(&account{}, &account{}, big.NewInt(0), 0, common.Address{}),
+		Contract: vm.NewContract(&account{}, &account{}, big.NewInt(0), 0, nil),
 	}
 	tracer.CaptureStart(env, common.Address{}, common.Address{}, false, []byte{}, 0, big.NewInt(0))
 	tracer.CaptureState(0, 0, 0, 0, scope, nil, 0, nil)
@@ -273,7 +273,7 @@ func TestEnterExit(t *testing.T) {
 		t.Fatal(err)
 	}
 	scope := &vm.ScopeContext{
-		Contract: vm.NewContract(&account{}, &account{}, big.NewInt(0), 0, common.Address{}),
+		Contract: vm.NewContract(&account{}, &account{}, big.NewInt(0), 0, nil),
 	}
 	tracer.CaptureEnter(vm.CALL, scope.Contract.Caller(), scope.Contract.Address(), []byte{}, 1000, new(big.Int))
 	tracer.CaptureExit([]byte{}, 400, nil)

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -56,7 +56,7 @@ func TestStoreCapture(t *testing.T) {
 	var (
 		logger   = NewStructLogger(nil)
 		env      = vm.NewEVM(vm.BlockContext{}, vm.TxContext{}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Tracer: logger})
-		contract = vm.NewContract(&dummyContractRef{}, &dummyContractRef{}, new(big.Int), 100000, common.Address{})
+		contract = vm.NewContract(&dummyContractRef{}, &dummyContractRef{}, new(big.Int), 100000, nil)
 	)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x0, byte(vm.SSTORE)}
 	var index common.Hash

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -71,6 +71,7 @@ type TxPool struct {
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
 	eip2718  bool // Fork indicator whether we are in the eip2718 stage.
 	shanghai bool // Fork indicator whether we are in the shanghai stage.
+	hydro    bool // Fork indicator whether we are in the hydro stage.
 }
 
 // TxRelayBackend provides an interface to the mechanism that forwards transactions to the
@@ -318,6 +319,7 @@ func (pool *TxPool) setNewHead(head *types.Header) {
 	next := new(big.Int).Add(head.Number, big.NewInt(1))
 	pool.istanbul = pool.config.IsIstanbul(next)
 	pool.eip2718 = pool.config.IsBerlin(next)
+	pool.hydro = pool.config.IsHydro(next)
 	pool.shanghai = pool.config.IsShanghai(uint64(time.Now().Unix()))
 }
 
@@ -386,7 +388,7 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	}
 
 	// Should supply enough intrinsic gas
-	gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, pool.istanbul, pool.shanghai, tx.IsMiningTx())
+	gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, pool.istanbul, pool.shanghai, pool.hydro, tx.IsMiningTx())
 	if err != nil {
 		return err
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -985,7 +985,7 @@ type Rules struct {
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
-	IsMerge, IsShanghai, IsCancun, IsPrague                 bool
+	IsMerge, IsShanghai, IsCancun, IsPrague, IsHydro        bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1010,5 +1010,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsShanghai:       c.IsShanghai(timestamp),
 		IsCancun:         c.IsCancun(timestamp),
 		IsPrague:         c.IsPrague(timestamp),
+		IsHydro:          c.IsHydro(num),
 	}
 }

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -229,7 +228,7 @@ func runBenchmark(b *testing.B, t *StateTest) {
 
 			// Create "contract" for sender to cache code analysis.
 			sender := vm.NewContract(vm.AccountRef(msg.From), vm.AccountRef(msg.From),
-				nil, 0, common.Address{})
+				nil, 0, nil)
 
 			var (
 				gasUsed uint64

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -55,7 +55,7 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 			return nil, nil, err
 		}
 		// Intrinsic gas
-		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, isHomestead, isIstanbul, false, tx.IsMiningTx())
+		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, isHomestead, isIstanbul, false, false, tx.IsMiningTx())
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
- In the evm, while processing contract call, it check for if is the mining contract, it won't count the gas used, but we forgot to check for the fork first and cause inconsistent gas used.