### PR TITLE
Increase kaspa difficulty: Accept 1 per 512 blocks (average probability)

### DIFF
--- a/consensus/misc/cip0001.go
+++ b/consensus/misc/cip0001.go
@@ -3,7 +3,7 @@ package misc
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/core/types"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -43,7 +43,7 @@ func TransactionMiningSubsidy(config *params.ChainConfig, block *big.Int) *big.I
 // Check to see if an algorithm number is presenting for ethash
 // Because before the Helium fork, we didn't verify the tx.Algorithm number, so all number = ethash, but we want it is 1.
 // Some miner set a different number (2, 3, 4) and the transaction is excuted success, now we have to defined all that number to be ethash
-func IsEthashAlgorithm(config *params.ChainConfig, blockTime uint64, algorithm types.PoWAlgorithm) bool {
+func IsEthashAlgorithm(config *params.ChainConfig, blockTime uint64, algorithm crosschain.PoWAlgorithm) bool {
 	// before helium fork, all number is ethash
 	if !config.IsHelium(blockTime) {
 		return true
@@ -51,7 +51,7 @@ func IsEthashAlgorithm(config *params.ChainConfig, blockTime uint64, algorithm t
 
 	// after helium fork, only number 1
 	switch algorithm {
-	case types.EthashAlgorithm:
+	case crosschain.EthashAlgorithm:
 		return true
 	}
 

--- a/consensus/misc/cip0002.go
+++ b/consensus/misc/cip0002.go
@@ -26,6 +26,12 @@ var (
 
 	mainPowMax = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
 
+	// mainPowMaxInLithiumFork is the highest proof of work value a Kaspa block can
+	// have for the lithium fork. It is the value 2^256 / 512. So left kaspa block is allowed to be transfered to canxium chain.
+	// EST: 10 BPS => 615937 blocks per year will be trans
+	targetPoWInLithiumFork = new(big.Int).Rsh(big.NewInt(1).Lsh(big.NewInt(1), 256), 0) // 2^256
+	maxPoWInLithiumFork    = targetPoWInLithiumFork.Div(targetPoWInLithiumFork, big.NewInt(512))
+
 	// Max milliseconds from current time allowed for blocks, before they're considered future blocks
 	allowedFutureBlockTimeMilliSeconds = uint64(12000)
 
@@ -36,7 +42,8 @@ var (
 	// map from first 3 days to base reward
 	KaspaCrossMiningIncentiveBaseRewards = [3]int64{600000, 400000, 200000}
 	// map from month to base reward: wei per params.KaspaMinAcceptableDifficulty difficulty, default 1000000
-	KaspaCrossMiningBaseRewards = [142]int64{183829, 91915, 45958, 25868, 23963, 23254, 22566, 21898, 21249, 20620, 20010, 19418, 18843, 18285, 17744, 17219, 16709, 16214, 15734, 15269, 14817, 14378, 13953, 13540, 13139, 12750, 12372, 12006, 11651, 11306, 10971, 10647, 10331, 10026, 9729, 9441, 9161, 8890, 8627, 8372, 8124, 7883, 7650, 7424, 7204, 6991, 6784, 6583, 6388, 6199, 6016, 5838, 5665, 5497, 5334, 5176, 5023, 4875, 4730, 4590, 4454, 4323, 4195, 4070, 3950, 3833, 3720, 3610, 3503, 3399, 3298, 3201, 3106, 3014, 2925, 2838, 2754, 2673, 2594, 2517, 2442, 2370, 2300, 2232, 2166, 2102, 2040, 1979, 1921, 1864, 1809, 1755, 1703, 1653, 1604, 1556, 1510, 1466, 1422, 1380, 1339, 1300, 1261, 1224, 1188, 1153, 1119, 1085, 1053, 1022, 992, 963, 934, 906, 880, 854, 828, 804, 780, 757, 735, 713, 692, 671, 651, 632, 613, 595, 578, 561, 544, 528, 512, 497, 482, 468, 454, 441, 428, 415, 403, 400}
+	KaspaCrossMiningBaseRewards        = [142]int64{183829, 91915, 45958, 25868, 23963, 23254, 22566, 21898, 21249, 20620, 20010, 19418, 18843, 18285, 17744, 17219, 16709, 16214, 15734, 15269, 14817, 14378, 13953, 13540, 13139, 12750, 12372, 12006, 11651, 11306, 10971, 10647, 10331, 10026, 9729, 9441, 9161, 8890, 8627, 8372, 8124, 7883, 7650, 7424, 7204, 6991, 6784, 6583, 6388, 6199, 6016, 5838, 5665, 5497, 5334, 5176, 5023, 4875, 4730, 4590, 4454, 4323, 4195, 4070, 3950, 3833, 3720, 3610, 3503, 3399, 3298, 3201, 3106, 3014, 2925, 2838, 2754, 2673, 2594, 2517, 2442, 2370, 2300, 2232, 2166, 2102, 2040, 1979, 1921, 1864, 1809, 1755, 1703, 1653, 1604, 1556, 1510, 1466, 1422, 1380, 1339, 1300, 1261, 1224, 1188, 1153, 1119, 1085, 1053, 1022, 992, 963, 934, 906, 880, 854, 828, 804, 780, 757, 735, 713, 692, 671, 651, 632, 613, 595, 578, 561, 544, 528, 512, 497, 482, 468, 454, 441, 428, 415, 403, 400}
+	KaspaCrossMiningLithiumBaseRewards = [142]int64{94120448, 47060480, 23530496, 13244416, 12269056, 11906048, 11553792, 11211776, 10879488, 10557440, 10245120, 9942016, 9647616, 9361920, 9084928, 8816128, 8555008, 8301568, 8055808, 7817728, 7586304, 7361536, 7143936, 6932480, 6727168, 6528000, 6334464, 6147072, 5965312, 5788672, 5617152, 5451264, 5289472, 5133312, 4981248, 4833792, 4690432, 4551680, 4417024, 4286464, 4159488, 4036096, 3916800, 3801088, 3688448, 3579392, 3473408, 3370496, 3270656, 3173888, 3080192, 2989056, 2900480, 2814464, 2731008, 2650112, 2571776, 2496000, 2421760, 2350080, 2280448, 2213376, 2147840, 2083840, 2022400, 1962496, 1904640, 1848320, 1793536, 1740288, 1688576, 1638912, 1590272, 1543168, 1497600, 1453056, 1410048, 1368576, 1328128, 1288704, 1250304, 1213440, 1177600, 1142784, 1108992, 1076224, 1044480, 1013248, 983552, 954368, 926208, 898560, 871936, 846336, 821248, 796672, 773120, 750592, 728064, 706560, 685568, 665600, 645632, 626688, 608256, 590336, 572928, 555520, 539136, 523264, 507904, 493056, 478208, 463872, 450560, 437248, 423936, 411648, 399360, 387584, 376320, 365056, 354304, 343552, 333312, 323584, 313856, 304640, 295936, 287232, 278528, 270336, 262144, 254464, 246784, 239616, 232448, 225792, 219136, 212480, 206336, 204800}
 )
 
 // Various error messages to mark blocks invalid. These should be private to
@@ -60,9 +67,20 @@ var (
 	ErrInvalidCrossChainBlock = errors.New("invalid cross mining transaction: invalid block")
 	ErrInvalidMergePoW        = errors.New("invalid cross mining transaction: invalid proof of work")
 	ErrInvalidMergeCoinbase   = errors.New("invalid cross mining transaction: invalid coinbase")
+	ErrInvalidBlockPoWHash    = errors.New("invalid cross mining transaction: invalid block PoW hash")
 
 	ErrUnauthorizedCrossMiningTx = errors.New("interact with crossChainMining method of mining contract from normal transaction is not allowed")
 )
+
+func isValidKaspaBlockHash(hashHex string) (bool, error) {
+	hashBytes, err := hex.DecodeString(hashHex)
+	if err != nil {
+		return false, err
+	}
+
+	hashInt := new(big.Int).SetBytes(hashBytes)
+	return hashInt.Cmp(maxPoWInLithiumFork) == -1, nil
+}
 
 // verifyCrossMiningTxSeal checks whether a cross mining satisfies the PoW difficulty requirements,
 func VerifyCrossMiningTxSeal(config *params.ChainConfig, tx *types.Transaction, block *types.Header) error {
@@ -74,6 +92,16 @@ func VerifyCrossMiningTxSeal(config *params.ChainConfig, tx *types.Transaction, 
 	}
 	if !isSupportedCrossMining(config, tx, block.Time) {
 		return ErrInvalidMiningTimeLine
+	}
+	// Ensure Daa Shift for kaspa chain
+	if config.IsLithium(block.Time) && tx.AuxPoW().Chain() == crosschain.KaspaChain {
+		valid, err := isValidKaspaBlockHash(tx.AuxPoW().BlockHash())
+		if err != nil {
+			return err
+		}
+		if !valid {
+			return ErrInvalidBlockPoWHash
+		}
 	}
 	// Ensure the receiver is the mining smart contract
 	if tx.To() == nil || *tx.To() != config.MiningContract {
@@ -100,7 +128,7 @@ func VerifyCrossMiningTxSeal(config *params.ChainConfig, tx *types.Transaction, 
 	}
 	// Ensure value is valid: reward * difficulty
 	chainForkTime := CrossMiningForkTime(config, crossBlock.Chain())
-	reward := CrossMiningReward(crossBlock, chainForkTime, block.Time)
+	reward := CrossMiningReward(config.IsLithium(block.Time), crossBlock, chainForkTime, block.Time)
 	if tx.Value().Cmp(reward) != 0 {
 		return ErrInvalidMiningTxValue
 	}
@@ -162,14 +190,14 @@ func CrossMiningForkTime(config *params.ChainConfig, parentChain crosschain.Cros
 }
 
 // Calculate cross mining reward
-func CrossMiningReward(crossBlock crosschain.CrossChainBlock, forkTime uint64, time uint64) *big.Int {
+func CrossMiningReward(isLithiumFork bool, crossBlock crosschain.CrossChainBlock, forkTime uint64, time uint64) *big.Int {
 	if time < forkTime {
 		return big0
 	}
 
 	switch crossBlock.Chain() {
 	case crosschain.KaspaChain:
-		reward := kaspaCrossMiningReward(crossBlock.Difficulty(), forkTime, time)
+		reward := kaspaCrossMiningReward(isLithiumFork, crossBlock.Difficulty(), forkTime, time)
 		return reward
 	}
 
@@ -196,16 +224,20 @@ func isSupportedCrossMining(config *params.ChainConfig, tx *types.Transaction, b
 }
 
 // kaspaCrossMiningReward calculate reward for the difficulty of a kaspa block
-func kaspaCrossMiningReward(difficulty *big.Int, forkTime uint64, time uint64) *big.Int {
+func kaspaCrossMiningReward(isLithiumFork bool, difficulty *big.Int, forkTime uint64, time uint64) *big.Int {
 	day, month := timePassedSinceFork(forkTime, time)
 	baseReward := new(big.Int)
+	baseRewards := KaspaCrossMiningBaseRewards
+	if isLithiumFork {
+		baseRewards = KaspaCrossMiningLithiumBaseRewards
+	}
 
 	if day < KaspaPhaseTwoDayNum {
 		baseReward.SetInt64(KaspaCrossMiningIncentiveBaseRewards[day])
 	} else if month < KaspaPhaseThreeMonth {
-		baseReward.SetInt64(KaspaCrossMiningBaseRewards[month])
+		baseReward.SetInt64(baseRewards[month])
 	} else {
-		baseReward.SetInt64(KaspaCrossMiningBaseRewards[KaspaPhaseThreeMonth])
+		baseReward.SetInt64(baseRewards[KaspaPhaseThreeMonth])
 	}
 
 	// Multiply difficulty * baseReward (per 1000000 hash) / 1000000

--- a/consensus/misc/cip0002.go
+++ b/consensus/misc/cip0002.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -141,7 +142,7 @@ func IsUnauthorizedCrossMiningTx(config *params.ChainConfig, tx *types.Transacti
 }
 
 // CrossMiningForkTimeMilli Return fork time, in millisecond to compare the merge block time
-func CrossMiningForkTimeMilli(config *params.ChainConfig, parentChain types.CrossChain) uint64 {
+func CrossMiningForkTimeMilli(config *params.ChainConfig, parentChain crosschain.CrossChain) uint64 {
 	forkTime := CrossMiningForkTime(config, parentChain)
 	if forkTime != math.MaxUint64 {
 		return forkTime * 1000
@@ -151,9 +152,9 @@ func CrossMiningForkTimeMilli(config *params.ChainConfig, parentChain types.Cros
 }
 
 // CrossMiningForkTime Return fork time, in second to calculate mining reward
-func CrossMiningForkTime(config *params.ChainConfig, parentChain types.CrossChain) uint64 {
+func CrossMiningForkTime(config *params.ChainConfig, parentChain crosschain.CrossChain) uint64 {
 	switch parentChain {
-	case types.KaspaChain:
+	case crosschain.KaspaChain:
 		return *config.HeliumTime
 	}
 
@@ -161,13 +162,13 @@ func CrossMiningForkTime(config *params.ChainConfig, parentChain types.CrossChai
 }
 
 // Calculate cross mining reward
-func CrossMiningReward(crossBlock types.CrossChainBlock, forkTime uint64, time uint64) *big.Int {
+func CrossMiningReward(crossBlock crosschain.CrossChainBlock, forkTime uint64, time uint64) *big.Int {
 	if time < forkTime {
 		return big0
 	}
 
 	switch crossBlock.Chain() {
-	case types.KaspaChain:
+	case crosschain.KaspaChain:
 		reward := kaspaCrossMiningReward(crossBlock.Difficulty(), forkTime, time)
 		return reward
 	}
@@ -176,9 +177,9 @@ func CrossMiningReward(crossBlock types.CrossChainBlock, forkTime uint64, time u
 }
 
 // CrossMiningMinDifficulty return the minimum difficulty for each chain
-func CrossMiningMinDifficulty(config *params.ChainConfig, parentChain types.CrossChain) *big.Int {
+func CrossMiningMinDifficulty(config *params.ChainConfig, parentChain crosschain.CrossChain) *big.Int {
 	switch parentChain {
-	case types.KaspaChain:
+	case crosschain.KaspaChain:
 		return config.CrossMining.MinimumKaspaDifficulty
 	}
 
@@ -187,7 +188,7 @@ func CrossMiningMinDifficulty(config *params.ChainConfig, parentChain types.Cros
 
 // isSupportedCrossMining check if this timeline support for this parent chain
 func isSupportedCrossMining(config *params.ChainConfig, tx *types.Transaction, blockTime uint64) bool {
-	if tx.AuxPoW().Chain() == types.KaspaChain {
+	if tx.AuxPoW().Chain() == crosschain.KaspaChain {
 		return config.IsHelium(blockTime)
 	}
 
@@ -224,7 +225,7 @@ func timePassedSinceFork(forkTime, time uint64) (dayNum uint64, month uint64) {
 	return
 }
 
-func buildCrossMiningTxInput(chain types.CrossChain, address common.Address, timestamp uint64) []byte {
+func buildCrossMiningTxInput(chain crosschain.CrossChain, address common.Address, timestamp uint64) []byte {
 	// Check input data, match: method_receiver_chain_timestamp
 	paddedAddress := common.LeftPadBytes(address.Bytes(), 32)
 	// Timestamp (uint256) is padded to 32 bytes

--- a/consensus/misc/cip0002_test.go
+++ b/consensus/misc/cip0002_test.go
@@ -63,60 +63,131 @@ func TestKaspaCrossMiningReward(t *testing.T) {
 	difficulty := big.NewInt(1000000000000000000) // Example difficulty value
 
 	// Calculate reward
-	rewardDay0 := kaspaCrossMiningReward(difficulty, 1704067200, 1704067300)
+	rewardDay0 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1704067300)
 	if rewardDay0.Cmp(big.NewInt(600000000000000000)) != 0 {
 		t.Errorf("Day 0: Reward %s should equal %d", rewardDay0.String(), 600000000000000000)
 	}
 
-	rewardDay1 := kaspaCrossMiningReward(difficulty, 1704067200, 1704157200)
+	rewardDay1 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1704157200)
 	if rewardDay1.Cmp(big.NewInt(400000000000000000)) != 0 {
 		t.Errorf("Day 1: Reward %s should equal %d", rewardDay1.String(), 400000000000000000)
 	}
 
-	rewardDay2 := kaspaCrossMiningReward(difficulty, 1704067200, 1704240000)
+	rewardDay2 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1704240000)
 	if rewardDay2.Cmp(big.NewInt(200000000000000000)) != 0 {
 		t.Errorf("Day 2: Reward %s should equal %d", rewardDay2.String(), 200000000000000000)
 	}
 
-	rewardDay3 := kaspaCrossMiningReward(difficulty, 1704067200, 1704326400)
+	rewardDay3 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1704326400)
 	if rewardDay3.Cmp(big.NewInt(183829000000000000)) != 0 {
 		t.Errorf("Day 3: Reward %s should equal %d", rewardDay3.String(), 183829000000000000)
 	}
 
-	rewardDay4 := kaspaCrossMiningReward(difficulty, 1704067200, 1704421800)
+	rewardDay4 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1704421800)
 	if rewardDay4.Cmp(big.NewInt(183829000000000000)) != 0 {
 		t.Errorf("Day 3: Reward %s should equal %d", rewardDay4.String(), 183829000000000000)
 	}
 
-	rewardDay33 := kaspaCrossMiningReward(difficulty, 1704067200, 1706920742)
+	rewardDay33 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1706920742)
 	if rewardDay33.Cmp(big.NewInt(91915000000000000)) != 0 {
 		t.Errorf("Day 33: Reward %s should equal %d", rewardDay33.String(), 91915000000000000)
 	}
 
-	rewardDay34 := kaspaCrossMiningReward(difficulty, 1704067200, 1707009800)
+	rewardDay34 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1707009800)
 	if rewardDay34.Cmp(big.NewInt(91915000000000000)) != 0 {
 		t.Errorf("Day 34: Reward %s should equal %d", rewardDay34.String(), 91915000000000000)
 	}
 
-	rewardDay110 := kaspaCrossMiningReward(difficulty, 1704067200, 1713574900)
+	rewardDay110 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1713574900)
 	if rewardDay110.Cmp(big.NewInt(25868000000000000)) != 0 {
 		t.Errorf("Day 110: Reward %s should equal %d", rewardDay110.String(), 25868000000000000)
 	}
 
-	rewardDay1735 := kaspaCrossMiningReward(difficulty, 1704067200, 1853974200)
+	rewardDay1735 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1853974200)
 	if rewardDay1735.Cmp(big.NewInt(4875000000000000)) != 0 {
 		t.Errorf("Day 1735: Reward %s should equal %d", rewardDay1735.String(), 4875000000000000)
 	}
 
-	rewardDay1736 := kaspaCrossMiningReward(difficulty, 1704067200, 1854060600)
+	rewardDay1736 := kaspaCrossMiningReward(false, difficulty, 1704067200, 1854060600)
 	if rewardDay1736.Cmp(big.NewInt(4875000000000000)) != 0 {
 		t.Errorf("Day 1735: Reward %s should equal %d", rewardDay1736.String(), 4875000000000000)
+	}
+
+	// Calculate reward
+	shiftRewardDay0 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1704067300)
+	expectedRewardDay0 := new(big.Int)
+	expectedRewardDay0.SetString("600000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay0.Cmp(expectedRewardDay0) != 0 {
+		t.Errorf("Day 0: Reward %s should equal %s", rewardDay0.String(), expectedRewardDay0.String())
+	}
+
+	shiftRewardDay1 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1704157200)
+	expectedShiftRewardDay1 := new(big.Int)
+	expectedShiftRewardDay1.SetString("400000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay1.Cmp(expectedShiftRewardDay1) != 0 {
+		t.Errorf("Day 1: Reward %s should equal %s", shiftRewardDay1.String(), expectedShiftRewardDay1.String())
+	}
+
+	shiftRewardDay2 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1704240000)
+	expectedShiftRewardDay2 := new(big.Int)
+	expectedShiftRewardDay2.SetString("200000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay2.Cmp(expectedShiftRewardDay2) != 0 {
+		t.Errorf("Day 2: Reward %s should equal %s", shiftRewardDay2.String(), expectedShiftRewardDay2.String())
+	}
+
+	shiftRewardDay3 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1704326400)
+	expectedShiftRewardDay3 := new(big.Int)
+	expectedShiftRewardDay3.SetString("183829000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay3.Cmp(expectedShiftRewardDay3) != 0 {
+		t.Errorf("Day 3: Reward %s should equal %s", shiftRewardDay3.String(), expectedShiftRewardDay3.String())
+	}
+
+	shiftRewardDay4 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1704421800)
+	expectedShiftRewardDay4 := new(big.Int)
+	expectedShiftRewardDay4.SetString("183829000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay4.Cmp(expectedShiftRewardDay4) != 0 {
+		t.Errorf("Day 4: Reward %s should equal %s", shiftRewardDay4.String(), expectedShiftRewardDay4.String())
+	}
+
+	shiftRewardDay33 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1706920742)
+	expectedShiftRewardDay33 := new(big.Int)
+	expectedShiftRewardDay33.SetString("91915000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay33.Cmp(expectedShiftRewardDay33) != 0 {
+		t.Errorf("Day 33: Reward %s should equal %s", shiftRewardDay33.String(), expectedShiftRewardDay33.String())
+	}
+
+	shiftRewardDay34 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1707009800)
+	expectedShiftRewardDay34 := new(big.Int)
+	expectedShiftRewardDay34.SetString("91915000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay34.Cmp(expectedShiftRewardDay34) != 0 {
+		t.Errorf("Day 34: Reward %s should equal %s", shiftRewardDay34.String(), expectedShiftRewardDay34.String())
+	}
+
+	shiftRewardDay110 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1713574900)
+	expectedShiftRewardDay110 := new(big.Int)
+	expectedShiftRewardDay110.SetString("25868000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay110.Cmp(expectedShiftRewardDay110) != 0 {
+		t.Errorf("Day 110: Reward %s should equal %s", shiftRewardDay110.String(), expectedShiftRewardDay110.String())
+	}
+
+	shiftRewardDay1735 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1853974200)
+	expectedShiftRewardDay1735 := new(big.Int)
+	expectedShiftRewardDay1735.SetString("4875000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay1735.Cmp(expectedShiftRewardDay1735) != 0 {
+		t.Errorf("Day 1735: Reward %s should equal %s", shiftRewardDay1735.String(), expectedShiftRewardDay1735.String())
+	}
+
+	shiftRewardDay1736 := kaspaCrossMiningReward(true, difficulty, 1704067200, 1854060600)
+	expectedShiftRewardDay1736 := new(big.Int)
+	expectedShiftRewardDay1736.SetString("4875000000000000000", 10) // Use SetString for large values
+	if shiftRewardDay1736.Cmp(expectedShiftRewardDay1736) != 0 {
+		t.Errorf("Day 1736: Reward %s should equal %s", shiftRewardDay1736.String(), expectedShiftRewardDay1736.String())
 	}
 
 	start := uint64(1704067200)
 	step := uint64(86399) // 16 hours
 	for i := uint64(0); i < 5405; i++ {
-		reward := kaspaCrossMiningReward(difficulty, start, start+step*i)
+		reward := kaspaCrossMiningReward(false, difficulty, start, start+step*i)
 		dayNum, month := timePassedSinceFork(start, start+step*i)
 		fmt.Printf("%d,%d,%s\n", dayNum, month, reward.String())
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -397,7 +398,7 @@ func (s *StateDB) HasSuicided(addr common.Address) bool {
 
 // GetCrossMiningTimestamp return cross mining timestamp of an address of a chain id
 // This data is set by miningContract.
-func (s *StateDB) GetCrossMiningTimestamp(contract common.Address, address common.Address, chain types.CrossChain) uint64 {
+func (s *StateDB) GetCrossMiningTimestamp(contract common.Address, address common.Address, chain crosschain.CrossChain) uint64 {
 	key := crossMiningStorageKey(address, uint16(chain))
 	data := s.GetState(contract, key)
 	return data.Big().Uint64()

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -133,7 +134,7 @@ type MergeMiningMessage struct {
 	ToContract common.Address
 	FromMiner  common.Address
 	BlockTime  uint64
-	FromChain  types.CrossChain
+	FromChain  crosschain.CrossChain
 }
 
 // A Message contains the data derived from a single transaction that is relevant to state

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -1769,7 +1769,8 @@ func (pool *TxPool) isValidMiningSubsidy(headNumber *big.Int, headTime uint64, t
 
 	if tx.Type() == types.CrossMiningTxType {
 		forkTime := misc.CrossMiningForkTime(pool.chainconfig, tx.AuxPoW().Chain())
-		value := misc.CrossMiningReward(tx.AuxPoW(), forkTime, headTime)
+		isLithiumFork := pool.chainconfig.IsLithium(headTime)
+		value := misc.CrossMiningReward(isLithiumFork, tx.AuxPoW(), forkTime, headTime)
 		return tx.Value().Cmp(value) == 0
 	}
 

--- a/core/types/cross-chain/kaspa_block.go
+++ b/core/types/cross-chain/kaspa_block.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package types
+package crosschain
 
 import (
 	"errors"
@@ -21,23 +21,6 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/utils/pow"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/transactionhelper"
 	"github.com/kaspanet/kaspad/util/difficulty"
-)
-
-const (
-	// prefix of kaspa miner in the coinbase transaction payload. To extract the canxium address
-	minerTagPrefix = "canxiuminer:"
-)
-
-var (
-	bigOne = big.NewInt(1)
-	// mainPowMax is the highest proof of work value a Kaspa block can
-	// have for the main network. It is the value 2^255 - 1.
-	mainPowMax  = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
-	zeroAddress = common.Address{}
-)
-
-var (
-	ErrInvalidCrossChainBlockHeader = errors.New("invalid cross mining block header")
 )
 
 // BlockHeader defines information about a block and is used in the bitcoin

--- a/core/types/cross-chain/types.go
+++ b/core/types/cross-chain/types.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package crosschain
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type PoWAlgorithm uint8
+
+// Transaction mining algorithm.
+const (
+	NoneAlgorithm PoWAlgorithm = iota
+	EthashAlgorithm
+	Sha256Algorithm
+	ScryptAlgorithm
+	KHeavyHashAlgorithm
+	RandomXAlgorithm
+)
+
+type CrossChain uint16
+
+const (
+	UnknownChain CrossChain = iota
+	KaspaChain
+	MoneroChain
+)
+
+const (
+	// prefix of kaspa miner in the coinbase transaction payload. To extract the canxium address
+	minerTagPrefix = "canxiuminer:"
+)
+
+var (
+	bigOne = big.NewInt(1)
+	// mainPowMax is the highest proof of work value a Kaspa block can
+	// have for the main network. It is the value 2^255 - 1.
+	mainPowMax  = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
+	zeroAddress = common.Address{}
+)
+
+var (
+	ErrInvalidCrossChainBlockHeader = errors.New("invalid cross mining block header")
+)
+
+type CrossChainBlock interface {
+	Chain() CrossChain
+	// Basic check if this is a valid cross mining block
+	IsValidBlock() bool
+	// Verify block PoW
+	VerifyPoW() error
+	// Verify coinbase transaction if follow consensus rules
+	VerifyCoinbase() bool
+	// Canxium miner address
+	GetMinerAddress() (common.Address, error)
+	// Block hash, in string
+	BlockHash() string
+	// Block difficulty
+	Difficulty() *big.Int
+	// Nonce number of the block
+	PowNonce() uint64
+	// block timestamp in millisecond
+	Timestamp() uint64
+	// PoW Algorithm
+	PoWAlgorithm() PoWAlgorithm
+	// Deep copy
+	Copy() CrossChainBlock
+}
+
+const (
+	// Monero constants
+	RandomXActivationTimestamp = 1561234567 // Example timestamp, replace with actual Monero RandomX activation timestamp
+)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -48,17 +49,6 @@ const (
 	MiningTxType
 
 	CrossMiningTxType = 126
-)
-
-type PoWAlgorithm uint8
-
-// Transaction mining algorithm.
-const (
-	NoneAlgorithm PoWAlgorithm = iota
-	EthashAlgorithm
-	Sha256Algorithm
-	ScryptAlgorithm
-	KHeavyHashAlgorithm
 )
 
 // Transaction is an Ethereum transaction.
@@ -111,13 +101,13 @@ type TxData interface {
 	effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int
 
 	// mining functions
-	algorithm() PoWAlgorithm
+	algorithm() crosschain.PoWAlgorithm
 	difficulty() *big.Int
 	powNonce() uint64
 	mixDigest() common.Hash
 
 	// cross mining functions
-	auxPoW() CrossChainBlock
+	auxPoW() crosschain.CrossChainBlock
 }
 
 // EncodeRLP implements rlp.Encoder
@@ -322,7 +312,7 @@ func (tx *Transaction) Value() *big.Int { return new(big.Int).Set(tx.inner.value
 func (tx *Transaction) Nonce() uint64 { return tx.inner.nonce() }
 
 // Algorithm returns the mining algorithm of transaction which miner choosed
-func (tx *Transaction) Algorithm() PoWAlgorithm { return tx.inner.algorithm() }
+func (tx *Transaction) Algorithm() crosschain.PoWAlgorithm { return tx.inner.algorithm() }
 
 // Difficulty returns the mining diffculty of transaction
 func (tx *Transaction) Difficulty() *big.Int { return tx.inner.difficulty() }
@@ -334,7 +324,7 @@ func (tx *Transaction) PowNonce() uint64 { return tx.inner.powNonce() }
 func (tx *Transaction) MixDigest() common.Hash { return tx.inner.mixDigest() }
 
 // Return the cross mining proof of work data
-func (tx *Transaction) AuxPoW() CrossChainBlock { return tx.inner.auxPoW() }
+func (tx *Transaction) AuxPoW() crosschain.CrossChainBlock { return tx.inner.auxPoW() }
 
 // Is this a mining transaction, use for gas free check only
 func (tx *Transaction) IsMiningTx() bool {

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 )
 
 // txJSON is the JSON representation of transactions.
@@ -54,7 +55,7 @@ type txJSON struct {
 	PowNonce   *hexutil.Uint64 `json:"powNonce,omitempty"`
 
 	// Cross Mining transaction
-	AuxPoW *CrossChainBlock `json:"auxPoW,omitempty"`
+	AuxPoW *crosschain.CrossChainBlock `json:"auxPoW,omitempty"`
 
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
@@ -366,7 +367,7 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.Algorithm == nil {
 			return errors.New("missing required field 'algorithm' in transaction")
 		}
-		itx.Algorithm = PoWAlgorithm(*dec.Algorithm)
+		itx.Algorithm = crosschain.PoWAlgorithm(*dec.Algorithm)
 		if dec.Difficulty == nil {
 			return errors.New("missing required field 'difficulty' in transaction")
 		}

--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 )
 
 //go:generate go run github.com/fjl/gencodec -type AccessTuple -out gen_access_tuple.go
@@ -108,13 +109,13 @@ func (tx *AccessListTx) to() *common.Address    { return tx.To }
 func (tx *AccessListTx) from() common.Address   { return common.Address{} }
 
 // mining
-func (tx *AccessListTx) algorithm() PoWAlgorithm { return NoneAlgorithm }
-func (tx *AccessListTx) difficulty() *big.Int    { return big.NewInt(0) }
-func (tx *AccessListTx) powNonce() uint64        { return 0 }
-func (tx *AccessListTx) mixDigest() common.Hash  { return common.Hash{} }
+func (tx *AccessListTx) algorithm() crosschain.PoWAlgorithm { return crosschain.NoneAlgorithm }
+func (tx *AccessListTx) difficulty() *big.Int               { return big.NewInt(0) }
+func (tx *AccessListTx) powNonce() uint64                   { return 0 }
+func (tx *AccessListTx) mixDigest() common.Hash             { return common.Hash{} }
 
 // cross mining
-func (tx *AccessListTx) auxPoW() CrossChainBlock { return nil }
+func (tx *AccessListTx) auxPoW() crosschain.CrossChainBlock { return nil }
 
 func (tx *AccessListTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
 	return dst.Set(tx.GasPrice)

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 )
 
 type DynamicFeeTx struct {
@@ -95,13 +96,13 @@ func (tx *DynamicFeeTx) nonce() uint64          { return tx.Nonce }
 func (tx *DynamicFeeTx) to() *common.Address    { return tx.To }
 func (tx *DynamicFeeTx) from() common.Address   { return common.Address{} }
 
-func (tx *DynamicFeeTx) algorithm() PoWAlgorithm { return NoneAlgorithm }
-func (tx *DynamicFeeTx) difficulty() *big.Int    { return big.NewInt(0) }
-func (tx *DynamicFeeTx) powNonce() uint64        { return 0 }
-func (tx *DynamicFeeTx) mixDigest() common.Hash  { return common.Hash{} }
+func (tx *DynamicFeeTx) algorithm() crosschain.PoWAlgorithm { return crosschain.NoneAlgorithm }
+func (tx *DynamicFeeTx) difficulty() *big.Int               { return big.NewInt(0) }
+func (tx *DynamicFeeTx) powNonce() uint64                   { return 0 }
+func (tx *DynamicFeeTx) mixDigest() common.Hash             { return common.Hash{} }
 
 // cross mining
-func (tx *DynamicFeeTx) auxPoW() CrossChainBlock { return nil }
+func (tx *DynamicFeeTx) auxPoW() crosschain.CrossChainBlock { return nil }
 
 func (tx *DynamicFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
 	if baseFee == nil {

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 )
 
 // LegacyTx is the transaction data of regular Ethereum transactions.
@@ -105,13 +106,13 @@ func (tx *LegacyTx) to() *common.Address    { return tx.To }
 func (tx *LegacyTx) from() common.Address   { return common.Address{} }
 
 // mining
-func (tx *LegacyTx) algorithm() PoWAlgorithm { return NoneAlgorithm }
-func (tx *LegacyTx) difficulty() *big.Int    { return big.NewInt(0) }
-func (tx *LegacyTx) powNonce() uint64        { return 0 }
-func (tx *LegacyTx) mixDigest() common.Hash  { return common.Hash{} }
+func (tx *LegacyTx) algorithm() crosschain.PoWAlgorithm { return crosschain.NoneAlgorithm }
+func (tx *LegacyTx) difficulty() *big.Int               { return big.NewInt(0) }
+func (tx *LegacyTx) powNonce() uint64                   { return 0 }
+func (tx *LegacyTx) mixDigest() common.Hash             { return common.Hash{} }
 
 // cross mining
-func (tx *LegacyTx) auxPoW() CrossChainBlock { return nil }
+func (tx *LegacyTx) auxPoW() crosschain.CrossChainBlock { return nil }
 
 func (tx *LegacyTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
 	return dst.Set(tx.GasPrice)

--- a/core/types/tx_mining.go
+++ b/core/types/tx_mining.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 )
 
 // A BlockNonce is a 64-bit hash which proves (combined with the
@@ -63,7 +64,7 @@ type MiningTx struct {
 	Data      []byte
 
 	// mining fields
-	Algorithm  PoWAlgorithm
+	Algorithm  crosschain.PoWAlgorithm
 	Difficulty *big.Int
 	MixDigest  common.Hash
 	PowNonce   PowNonce // mining nonce
@@ -140,13 +141,13 @@ func (tx *MiningTx) to() *common.Address    { return &tx.To }
 func (tx *MiningTx) from() common.Address   { return tx.From }
 
 // mining fields
-func (tx *MiningTx) algorithm() PoWAlgorithm { return tx.Algorithm }
-func (tx *MiningTx) difficulty() *big.Int    { return tx.Difficulty }
-func (tx *MiningTx) powNonce() uint64        { return tx.PowNonce.Uint64() }
-func (tx *MiningTx) mixDigest() common.Hash  { return tx.MixDigest }
+func (tx *MiningTx) algorithm() crosschain.PoWAlgorithm { return tx.Algorithm }
+func (tx *MiningTx) difficulty() *big.Int               { return tx.Difficulty }
+func (tx *MiningTx) powNonce() uint64                   { return tx.PowNonce.Uint64() }
+func (tx *MiningTx) mixDigest() common.Hash             { return tx.MixDigest }
 
 // cross mining
-func (tx *MiningTx) auxPoW() CrossChainBlock { return nil }
+func (tx *MiningTx) auxPoW() crosschain.CrossChainBlock { return nil }
 
 func (tx *MiningTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
 	if baseFee == nil {

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -587,7 +587,7 @@ func TestOpTstore(t *testing.T) {
 		caller         = common.Address{}
 		to             = common.Address{1}
 		contractRef    = contractRef{caller}
-		contract       = NewContract(contractRef, AccountRef(to), new(big.Int), 0, common.Address{})
+		contract       = NewContract(contractRef, AccountRef(to), new(big.Int), 0, &common.Address{})
 		scopeContext   = ScopeContext{mem, stack, contract}
 		value          = common.Hex2Bytes("abcdef00000000000000abba000000000deaf000000c0de00100000000133700")
 	)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	crosschain "github.com/ethereum/go-ethereum/core/types/cross-chain"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -51,7 +52,7 @@ type StateDB interface {
 	GetTransientState(addr common.Address, key common.Hash) common.Hash
 	SetTransientState(addr common.Address, key, value common.Hash)
 
-	GetCrossMiningTimestamp(common.Address, common.Address, types.CrossChain) uint64
+	GetCrossMiningTimestamp(common.Address, common.Address, crosschain.CrossChain) uint64
 
 	Suicide(common.Address) bool
 	HasSuicided(common.Address) bool

--- a/genesis/mainnet.genesis.json
+++ b/genesis/mainnet.genesis.json
@@ -23,6 +23,7 @@
     "terminalTotalDifficulty": 86680000000000000000,
     "shanghaiTime": 1723122376,
     "heliumTime": 1740787200,
+    "lithiumTime": 1749686400,
     "miningContract": "0x6c6331CA2BC039996E833479b7c13Cc62Ab5c6BA"
   },
   "difficulty": "400000",

--- a/genesis/mainnet.genesis.json
+++ b/genesis/mainnet.genesis.json
@@ -23,7 +23,7 @@
     "terminalTotalDifficulty": 86680000000000000000,
     "shanghaiTime": 1723122376,
     "heliumTime": 1740787200,
-    "lithiumTime": 1749686400,
+    "lithiumTime": 1749795180,
     "miningContract": "0x6c6331CA2BC039996E833479b7c13Cc62Ab5c6BA"
   },
   "difficulty": "400000",

--- a/params/config.go
+++ b/params/config.go
@@ -443,6 +443,8 @@ type ChainConfig struct {
 
 	// Fork for canxium chain, after PoS
 	HeliumTime *uint64 `json:"heliumTime,omitempty"` // Second hardfork, to support cross mining
+	// T filter out kaspa block to reduce the impact of kaspa mining
+	LithiumTime *uint64 `json:"lithiumTime,omitempty"`
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -602,6 +604,9 @@ func (c *ChainConfig) Description() string {
 	if c.HeliumTime != nil {
 		banner += fmt.Sprintf(" - Helium:                	   @%-10v \n", *c.HeliumTime)
 	}
+	if c.LithiumTime != nil {
+		banner += fmt.Sprintf(" - Lithium:                	   @%-10v \n", *c.LithiumTime)
+	}
 
 	banner += "\n"
 	// Create a list of forks post-merge
@@ -725,6 +730,11 @@ func (c *ChainConfig) IsHydro(num *big.Int) bool {
 // IsHelium returns whether num is either equal to the helium fork time or greater.
 func (c *ChainConfig) IsHelium(time uint64) bool {
 	return isTimestampForked(c.HeliumTime, time)
+}
+
+// IsLithium returns whether num is either equal to the Lithium fork time or greater.
+func (c *ChainConfig) IsLithium(time uint64) bool {
+	return isTimestampForked(c.LithiumTime, time)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported


### PR DESCRIPTION
- Reduce kaspa mining space by 512 times by this formula.
```
targetPoWInLithiumFork = new(big.Int).Rsh(big.NewInt(1).Lsh(big.NewInt(1), 256), 0) // 2^256
maxPoWInLithiumFork    = targetPoWInLithiumFork.Div(targetPoWInLithiumFork, big.NewInt(512))

Accept if: Kaspa Block Hash < maxPoWInLithiumFork

```

- Increase cross-chain mining reward for Kaspa block by 512 times.